### PR TITLE
fix: export session config object

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -218,8 +218,9 @@ export default {
 
 // Export all configurations for named imports
 export {
+    SESSION_CONFIG,
     FSRS_RATINGS,
-    CARD_STATES, 
+    CARD_STATES,
     FLAG_REASONS,
     USER_TIERS,
     DAILY_LIMITS,


### PR DESCRIPTION
## Summary
- export `SESSION_CONFIG` from `config.js` so modules can import it directly and avoid `Importing binding name 'SESSION_CONFIG' is not found` errors

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68988b8d23788325a92ce7bd5e2add94