### PR TITLE
Export cache configuration from config module

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -211,10 +211,12 @@ export default {
     FSRS_CONFIG,
     TIMEZONE_CONFIG,
     STREAK_CONFIG,
+    CACHE_CONFIG,
     LOADING_CONFIG,
     DECK_CONFIG,
     CARD_TEMPLATE_CONFIG
 };
+
 
 // Export all configurations for named imports
 export {
@@ -227,6 +229,7 @@ export {
     FSRS_CONFIG,
     TIMEZONE_CONFIG,
     STREAK_CONFIG,
+    CACHE_CONFIG,
     LOADING_CONFIG,
     DECK_CONFIG,
     CARD_TEMPLATE_CONFIG


### PR DESCRIPTION
## Summary
- export CACHE_CONFIG from js/config for both default and named imports
- ensure sessionManager.js loads without missing binding errors

## Testing
- `node --input-type=module -e "import('./js/sessionManager.js').then(()=>console.log('loaded')).catch(err=>console.error(err))"`
- `npm test >/tmp/test.log 2>&1; tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68988f43c6788325893044c806c44c46