### PR TITLE
Add ESLint configuration and lint CI workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "plugins": ["import"],
+  "rules": {
+    "import/no-unresolved": "error"
+  }
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+import pluginImport from "eslint-plugin-import";
+
+export default [
+  {
+    files: ["js/**/*.js", "scripts/**/*.js", "config/**/*.js", "tests/**/*.js"],
+    languageOptions: {
+      sourceType: "module",
+      ecmaVersion: "latest"
+    },
+    plugins: {
+      import: pluginImport
+    },
+    rules: {
+      "import/no-unresolved": "error"
+    }
+  },
+  {
+    files: ["scripts/**/*.js"],
+    languageOptions: {
+      sourceType: "commonjs"
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "migrate": "node migration/migrate-cards.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "audit-imports": "node scripts/audit-imports.js"
+    "audit-imports": "node scripts/audit-imports.js",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0"
   },
   "devDependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "eslint": "^9.32.0",
+    "eslint-plugin-import": "^2.29.1"
   }
 }


### PR DESCRIPTION
## Summary
- configure ESLint with import plugin and rule for unresolved imports
- add npm script `lint` and GitHub Actions workflow to run it

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-import')*


------
https://chatgpt.com/codex/tasks/task_e_6898986c338083259cfe307ea0393b30