### PR TITLE
Add JS build step and CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  lint:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,3 +16,5 @@ jobs:
           node-version: 18
       - run: npm ci
       - run: npm run lint
+      - run: npm test
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ coverage/
 .nyc_output/
 test-results/
 *.test.local.js
+dist/
 
 # Test files in root directory
 test-*.html

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "scripts": {
     "migrate": "node migration/migrate-cards.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node scripts/audit-imports.js",
     "audit-imports": "node scripts/audit-imports.js",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "node scripts/build.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+// Simple build script that verifies module imports and bundles JS sources
+// into a single dist/bundle.js file. Any import/export issues or syntax
+// errors will cause the build to fail.
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// First, audit imports to catch missing exports or unresolved files
+try {
+  execSync('node scripts/audit-imports.js', { stdio: 'inherit' });
+} catch (err) {
+  process.exit(1);
+}
+
+const srcDir = path.join(__dirname, '..', 'js');
+const outDir = path.join(__dirname, '..', 'dist');
+
+// Ensure fresh dist directory
+if (fs.existsSync(outDir)) {
+  fs.rmSync(outDir, { recursive: true, force: true });
+}
+fs.mkdirSync(outDir, { recursive: true });
+
+// Concatenate all JS files into a single bundle
+const files = fs
+  .readdirSync(srcDir)
+  .filter((f) => f.endsWith('.js'));
+
+let bundle = '';
+for (const file of files) {
+  const content = fs.readFileSync(path.join(srcDir, file), 'utf8');
+  bundle += `// ${file}\n${content}\n`;
+}
+
+const bundlePath = path.join(outDir, 'bundle.js');
+fs.writeFileSync(bundlePath, bundle);
+
+// Perform a syntax check on the generated bundle
+try {
+  execSync(`node --check ${bundlePath}`, { stdio: 'inherit' });
+  console.log(`Bundled ${files.length} files into ${bundlePath}`);
+} catch (err) {
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- add custom Node-based build script that audits imports and bundles js sources
- add build script and test command in package.json
- extend CI workflow to run lint, tests, and build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68989a7d4978832595906f8b8151d603