### PR TITLE
fix: join card templates when fetching due cards

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -1881,9 +1881,11 @@ async function initializeUserProgress(userId) {
  */
 async function getDueCards(userId) {
     try {
-        
+        validateUserId(userId, 'getting due cards');
+
+        const supabase = await getSupabaseClient();
         const now = new Date().toISOString();
-        
+
         // Get cards that are either:
         // 1. Due for review (due_at <= now)
         // 2. New cards (state = 'new')
@@ -1891,7 +1893,7 @@ async function getDueCards(userId) {
             .from('user_cards')
             .select(`
                 *,
-                cards (
+                card_templates (
                     id,
                     question,
                     answer,
@@ -1912,10 +1914,10 @@ async function getDueCards(userId) {
 
         // Transform the data to a more usable format
         const dueCards = data.map(record => ({
-            id: record.cards.id,
+            id: record.card_template_id,
             question: record.card_templates.question,
             answer: record.card_templates.answer,
-            subject_id: record.cards.subject_id,
+            subject_id: record.card_templates.subject_id,
             progress: {
                 stability: record.stability,
                 difficulty: record.difficulty,


### PR DESCRIPTION
## Summary
- fix getDueCards to join `card_templates` and map fields correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898a73693848325b86e8db7e24e448a