### PR TITLE
fix: install ripgrep in GitHub Actions for build script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
       - run: npm ci
       - run: npm run build
       - name: Setup Pages


### PR DESCRIPTION
The build script requires ripgrep but it's not available by default in GitHub Actions runners.

🤖 Generated with [Claude Code](https://claude.ai/code)