### PR TITLE
Add dynamic Supabase config loader

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -131,7 +131,7 @@
     <!-- Supabase Client Library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <!-- Application Scripts -->
-    <script src="config/supabase-config.js"></script>
+    <script src="js/config-loader.js" data-config-path="config/"></script>
     <script src="js/supabase-client.js" type="module"></script>
     <script src="js/auth.js" type="module"></script>
     <script src="js/navigation.js" type="module"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="css/slide-menu.css?v=1">
     <!-- Supabase Client Library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="config/supabase-config.js"></script>
+    <script src="js/config-loader.js" data-config-path="config/"></script>
     <script src="js/supabase-client.js" type="module"></script>
     <script src="js/auth.js" type="module"></script>
     <script src="js/database.js" type="module"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
     <!-- Supabase Client Library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <!-- Application Scripts -->
-    <script src="config/supabase-config.js"></script>
+    <script src="js/config-loader.js" data-config-path="config/"></script>
     <script src="js/supabase-client.js" type="module"></script>
     <script src="js/auth.js" type="module"></script>
     <script src="js/database.js" type="module"></script>

--- a/js/config-loader.js
+++ b/js/config-loader.js
@@ -1,0 +1,27 @@
+(function() {
+    const scriptTag = document.currentScript;
+    const basePath = scriptTag && scriptTag.dataset.configPath ? scriptTag.dataset.configPath : 'config/';
+
+    function inject(code) {
+        const s = document.createElement('script');
+        s.textContent = code;
+        document.head.appendChild(s);
+    }
+
+    function loadConfig(path) {
+        return fetch(path)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Failed to load ' + path);
+                }
+                return response.text();
+            })
+            .then(code => inject(code));
+    }
+
+    loadConfig(basePath + 'supabase-config.js')
+        .catch(() => {
+            console.warn('Supabase configuration not found. Using example configuration.');
+            return loadConfig(basePath + 'supabase-config.example.js');
+        });
+})();

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -43,7 +43,7 @@ async function initializeSupabase() {
 
         const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.supabaseConfig;
 
-        if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+        if (!SUPABASE_URL || !SUPABASE_ANON_KEY || SUPABASE_URL.includes('YOUR_SUPABASE_URL') || SUPABASE_ANON_KEY.includes('YOUR_SUPABASE_ANON_KEY')) {
             throw new Error('Missing Supabase configuration values');
         }
 

--- a/login.html
+++ b/login.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="css/onboarding.css?v=15">
     <!-- Include Supabase client library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="config/supabase-config.js"></script>
+    <script src="js/config-loader.js" data-config-path="config/"></script>
     <script src="js/supabase-client.js" type="module"></script>
     <script src="js/auth.js" type="module"></script>
     <script src="js/logoLoader.js" type="module"></script>

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="css/profile.css?v=1">
     <!-- Supabase Client Library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="config/supabase-config.js"></script>
+    <script src="js/config-loader.js" data-config-path="config/"></script>
     <script src="js/supabase-client.js" type="module"></script>
     <script src="js/auth.js" type="module"></script>
     <script src="js/userAvatar.js" type="module"></script>

--- a/reset-cards.html
+++ b/reset-cards.html
@@ -23,7 +23,7 @@
 
     <!-- Supabase Client Library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="config/supabase-config.js"></script>
+    <script src="js/config-loader.js" data-config-path="config/"></script>
     <script src="js/supabase-client.js" type="module"></script>
     
     <script type="module">

--- a/reset-password.html
+++ b/reset-password.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="css/auth.css?v=6">
     <!-- Include Supabase client library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="config/supabase-config.js"></script>
+    <script src="js/config-loader.js" data-config-path="config/"></script>
     <script src="js/supabase-client.js" type="module"></script>
     <script src="js/logoLoader.js" type="module"></script>
 </head>

--- a/tests/database-test.html
+++ b/tests/database-test.html
@@ -122,7 +122,7 @@
     </div>
 
     <!-- Load configuration first -->
-    <script src="../config/supabase-config.js"></script>
+    <script src="../js/config-loader.js" data-config-path="../config/"></script>
     
     <!-- Supabase Client Library -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>

--- a/tests/e2e-security-test.html
+++ b/tests/e2e-security-test.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>End-to-End Security Tests</title>
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-    <script src="../config/supabase-config.js"></script>
+    <script src="../js/config-loader.js" data-config-path="../config/"></script>
     <script src="test-config.js"></script>
 </head>
 <body>

--- a/tests/function-signature-test.html
+++ b/tests/function-signature-test.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Function Signature & Behavior Tests</title>
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-    <script src="../config/supabase-config.js"></script>
+    <script src="../js/config-loader.js" data-config-path="../config/"></script>
     <script src="test-config.js"></script>
 </head>
 <body>

--- a/tests/index.html
+++ b/tests/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Migration 31 Test Suite</title>
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-    <script src="../config/supabase-config.js"></script>
+    <script src="../js/config-loader.js" data-config-path="../config/"></script>
     <script src="test-config.js"></script>
     <style>
         .test-suite-container {

--- a/tests/migration-31-security-test.html
+++ b/tests/migration-31-security-test.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Migration 31 Security Function Tests</title>
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-    <script src="../config/supabase-config.js"></script>
+    <script src="../js/config-loader.js" data-config-path="../config/"></script>
     <script src="test-config.js"></script>
 </head>
 <body>

--- a/tests/schema-integrity-test.html
+++ b/tests/schema-integrity-test.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Database Schema Integrity Tests</title>
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-    <script src="../config/supabase-config.js"></script>
+    <script src="../js/config-loader.js" data-config-path="../config/"></script>
     <script src="test-config.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load Supabase configuration dynamically with fallback to example file
- update HTML pages and tests to use the loader instead of missing config file
- guard against placeholder Supabase credentials in the client initializer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898bfaece8c8325addb234eb08c6be9