### PR TITLE
Ensure Supabase client uses GitHub secrets

### DIFF
--- a/js/config-loader.js
+++ b/js/config-loader.js
@@ -20,8 +20,10 @@
     }
 
     loadConfig(basePath + 'supabase-config.js')
-        .catch(() => {
-            console.warn('Supabase configuration not found. Using example configuration.');
-            return loadConfig(basePath + 'supabase-config.example.js');
+        .catch((error) => {
+            console.error('Supabase configuration not found. Ensure GitHub secrets are configured.', error);
+            if (typeof window !== 'undefined') {
+                window.supabaseConfigError = 'Supabase configuration not found';
+            }
         });
 })();

--- a/js/script.js
+++ b/js/script.js
@@ -10,6 +10,7 @@ import { handleError } from './errorHandler.js';
 
 // Use global Supabase client
 const supabase = window.supabaseClient;
+const supabaseInitializationError = window.supabaseClientError || window.supabaseConfigError || null;
 
 /**
  * Check if user is admin and show admin navigation link
@@ -262,6 +263,16 @@ function showLoading(show) {
 
 function showError(message) {
     transitionToState('error', message);
+}
+
+// Make showError available globally for early error handling
+window.showError = showError;
+
+// If Supabase failed to initialize, show error and stop further execution
+if (!supabase) {
+    const message = supabaseInitializationError || 'Supabase client failed to initialize. Please check your configuration.';
+    showError(message);
+    throw new Error(message);
 }
 
 function showContent(show) {

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -57,10 +57,17 @@ async function initializeSupabase() {
         return supabase;
     } catch (error) {
         // Failed to initialize Supabase client
-        
+
         // Clear the failed client
         supabase = null;
-        
+
+        if (typeof window !== 'undefined') {
+            window.supabaseClientError = error.message;
+            if (typeof window.showError === 'function') {
+                window.showError(error.message || 'Failed to initialize Supabase client.');
+            }
+        }
+
         // Retry initialization if under max retries
         if (initializationRetries < MAX_RETRIES) {
             initializationRetries++;
@@ -68,7 +75,7 @@ async function initializeSupabase() {
             await new Promise(resolve => setTimeout(resolve, RETRY_DELAY));
             return initializeSupabase();
         }
-        
+
         throw error;
     }
 }


### PR DESCRIPTION
## Summary
- Remove fallback to placeholder Supabase config and flag missing secrets
- Record Supabase client initialization errors for the UI
- Expose `showError` globally and block app startup when Supabase fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898c9aebdd88325b92fd498c6cdda33