### PR TITLE
Wait for Supabase config before initialization

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -7,9 +7,10 @@ import { SESSION_CONFIG } from './config.js';
 import NavigationController from './navigation.js';
 import slideMenu from './slideMenu.js';
 import { handleError } from './errorHandler.js';
+import { getSupabaseClient } from './supabase-client.js';
 
-// Use global Supabase client
-const supabase = window.supabaseClient;
+// Supabase client instance
+let supabase;
 
 /**
  * Check if user is admin and show admin navigation link
@@ -1274,6 +1275,9 @@ const errorState = document.getElementById('error-state');
 // Initialize the app
 async function initializeApp() {
     try {
+        // Ensure Supabase client is ready
+        supabase = await getSupabaseClient();
+
         // Initialize loading messages service FIRST so it's ready for dynamic messages
         try {
             const { default: loadingMessagesService } = await import('./loadingMessages.js');

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -28,6 +28,21 @@ async function waitForSupabaseLibrary() {
     throw new Error('Supabase library failed to load');
 }
 
+async function waitForSupabaseConfig() {
+    let attempts = 0;
+    const maxAttempts = 50;
+    const delay = 100; // 100ms between attempts
+
+    while (attempts < maxAttempts) {
+        if (window.supabaseConfig) {
+            return true;
+        }
+        await new Promise(resolve => setTimeout(resolve, delay));
+        attempts++;
+    }
+    throw new SupabaseConfigError('Supabase configuration not loaded');
+}
+
 async function initializeSupabase() {
     try {
         // Return existing client if already initialized
@@ -40,12 +55,9 @@ async function initializeSupabase() {
             return await initializationPromise;
         }
 
-        // Wait for Supabase library to be available
+        // Wait for Supabase library and configuration to be available
         await waitForSupabaseLibrary();
-
-        if (!window.supabaseConfig) {
-            throw new SupabaseConfigError('Supabase configuration not found.');
-        }
+        await waitForSupabaseConfig();
 
         const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.supabaseConfig;
         const missingValues = !SUPABASE_URL || !SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- add polling in Supabase client to wait for configuration script
- fetch Supabase client lazily in script module instead of reading global directly

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-import')*


------
https://chatgpt.com/codex/tasks/task_e_6898e05c88f08325845041740e1493b6