### PR TITLE
Handle empty deck list in admin loadAllDecks

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1451,6 +1451,14 @@ class AdminService {
 
             // Get card counts for each deck
             const deckIds = decks?.map(d => d.id) || [];
+
+            // If there are no decks, display an empty list and exit early
+            if (deckIds.length === 0) {
+                this.displayDecks([], 'All Active Decks');
+                this.showInfo('No decks found');
+                return;
+            }
+
             const { data: cardCounts, error: countError } = await supabase
                 .from('user_cards')
                 .select('deck_id')


### PR DESCRIPTION
## Summary
- Prevent querying `user_cards` when no decks exist.
- Show a friendly notification and empty deck list when no decks are found.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e969e2048325866e0927f9676050