### PR TITLE
fix: animate saving spinner

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -677,6 +677,14 @@ async function handleSessionComplete() {
     try {
         // Start saving state for batch submission
         await transitionToState('saving', 'Saving your progress...');
+        // Yield to the browser so the spinner can animate
+        await new Promise(resolve => {
+            if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(() => requestAnimationFrame(resolve));
+            } else {
+                setTimeout(resolve, 0);
+            }
+        });
 
         // Get session data BEFORE clearing for completion statistics
         const sessionData = appState.sessionManager.getSessionData();


### PR DESCRIPTION
## Summary
- Allow saving spinner to render before processing session completion
- Double requestAnimationFrame so main thread work starts after paint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689996012f448325ab9f63659ea27133