### PR TITLE
fix: load supabase for admin page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -88,6 +88,12 @@
             </section>
         </div>
     </div>
+    <!-- Supabase Client Library -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <!-- Configuration Loader -->
+    <script src="js/config-loader.js" data-config-path="config/"></script>
+    <!-- Supabase Client Initialization -->
+    <script src="js/supabase-client.js" type="module"></script>
 
     <script type="module">
         import auth from './js/auth.js';


### PR DESCRIPTION
## Summary
- ensure admin dashboard loads Supabase client and configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f5e98d8648325b99e6a1f78dda019