### PR TITLE
Enhance admin flagged card summaries with card stats

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -512,6 +512,22 @@ body {
     font-weight: 600;
 }
 
+.flagged-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 8px 0;
+}
+
+.flagged-stats span {
+    font-size: 14px;
+    color: #ccc;
+}
+
+.flagged-stats span strong {
+    color: white;
+}
+
 .card-actions {
     margin-top: 15px;
     display: flex;


### PR DESCRIPTION
## Summary
- fetch card template stats when loading flagged cards
- show review totals, accuracy and avg response time in admin card summaries
- style flagged card metrics for responsive layout

## Testing
- `npm run audit-imports`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6c8d00fc832587c7610021d1d167