### PR TITLE
Add deck-specific study practice mode

### DIFF
--- a/css/deck-selection.css
+++ b/css/deck-selection.css
@@ -171,6 +171,14 @@
     overflow: hidden;
 }
 
+.deck-description.practice-note {
+    margin-top: -8px;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.6);
+    -webkit-line-clamp: unset;
+    overflow: visible;
+}
+
 /* Deck Statistics */
 .deck-stats {
     display: flex;

--- a/deck-study.html
+++ b/deck-study.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Deck Study - nanotopic</title>
+    
+    <!-- Security headers for production -->
+    <script>
+        // Only add security headers in production (not localhost)
+        if (!window.location.hostname.includes('localhost') && window.location.hostname !== '127.0.0.1') {
+            document.write('<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">');
+            document.write('<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload">');
+        }
+    </script>
+    
+    <!-- Mobile-specific meta tags for better experience -->
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-touch-fullscreen" content="yes">
+    <meta name="format-detection" content="telephone=no">
+    <link rel="stylesheet" href="css/styles.css?v=6">
+    <link rel="stylesheet" href="css/streak-styles.css?v=2">
+    <link rel="stylesheet" href="css/slide-menu.css?v=1">
+    <link rel="stylesheet" href="css/spinner.css?v=1">
+</head>
+<body data-study-mode="deck">
+    <div id="app-container">
+        <div id="loading-state" class="loading-state">
+            <div class="loading-content">
+                <div class="loading-spinner"></div>
+                <p class="loading-text"></p>
+            </div>
+        </div>
+        <div id="error-state" class="error-state hidden">
+            <div class="error-content">
+                <p id="error-message" class="error-text">Failed to load flashcards.</p>
+                <div class="error-actions">
+                    <button id="retry-button" class="nav-button">Try Again</button>
+                    <button id="error-logout-button" class="nav-button">Sign Out</button>
+                </div>
+            </div>
+        </div>
+        <div id="saving-state" class="saving-state hidden">
+            <div class="saving-content">
+                <div class="saving-spinner"></div>
+                <p class="saving-text">Wrapping up your practice session...</p>
+            </div>
+        </div>
+        <div id="content" class="content hidden">
+            <div class="progress-container">
+                <div class="progress-bar hidden" id="progress-bar">
+                    <div class="progress-fill" id="progress-fill"></div>
+                </div>
+                <div class="progress-text hidden" id="progress-text">Card 1</div>
+            </div>
+            <div class="card">
+                <div class="card-inner">
+                    <div class="card-front">
+                        <div class="last-seen-indicator" id="last-seen-front">Never</div>
+                        <p>Front of card (Question)</p>
+                    </div>
+                    <div class="card-back">
+                        <div class="last-seen-indicator" id="last-seen-back">Never</div>
+                        <p>Back of card (Answer)</p>
+                    </div>
+                </div>
+                <!-- Flag button overlay: shown when card is revealed -->
+                <button id="flag-overlay-button" class="flag-button flag-overlay" title="Report this card" aria-label="Report this card">🚩</button>
+            </div>
+            <div class="controls">
+                <div class="primary-controls">
+                    <button id="flip-button" class="nav-button">Flip</button>
+                </div>
+                <div id="rating-buttons" class="rating-buttons hidden">
+                    <button id="rate-again" class="rating-button rating-again" data-rating="1">Again</button>
+                    <button id="rate-known" class="rating-button rating-known" data-rating="3">Known</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Flag Card Modal -->
+    <div id="flag-modal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Report this card</h3>
+                <button id="modal-close" class="modal-close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p>Why are you reporting this card?</p>
+                <div class="flag-reasons">
+                    <label class="reason-option">
+                        <input type="radio" name="flag-reason" value="incorrect">
+                        <span>Incorrect answer</span>
+                    </label>
+                    <label class="reason-option">
+                        <input type="radio" name="flag-reason" value="spelling">
+                        <span>Spelling or grammar error</span>
+                    </label>
+                    <label class="reason-option">
+                        <input type="radio" name="flag-reason" value="confusing">
+                        <span>Confusing or unclear</span>
+                    </label>
+                    <label class="reason-option">
+                        <input type="radio" name="flag-reason" value="other">
+                        <span>Other issue</span>
+                    </label>
+                </div>
+                <div id="other-reason-input" class="other-reason hidden">
+                    <textarea id="other-reason-text" placeholder="Please describe the issue..." maxlength="250"></textarea>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="cancel-flag" class="nav-button">Cancel</button>
+                <button id="submit-flag" class="nav-button" disabled>Report Card</button>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Supabase Client Library -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <!-- Application Scripts -->
+    <script src="js/config-loader.js" data-config-path="config/"></script>
+    <script src="js/supabase-client.js" type="module"></script>
+    <script src="js/auth.js" type="module"></script>
+    <script src="js/database.js" type="module"></script>
+    <script src="js/fsrs.js" type="module"></script>
+    <script src="js/sessionManager.js" type="module"></script>
+    <script src="js/navigation.js" type="module"></script>
+    <script src="js/userAvatar.js" type="module"></script>
+    <script src="js/slideMenu.js" type="module"></script>
+    <script src="js/logoLoader.js" type="module"></script>
+    <script src="js/script.js" type="module"></script>
+</body>
+</html> 

--- a/js/deckSelection.js
+++ b/js/deckSelection.js
@@ -51,7 +51,7 @@ function calculateOverallStats(decks) {
 function renderDeckCard(deck) {
     const safeName = Validator.escapeHtml(deck.deck_name || 'Unnamed Deck');
     const safeDescription = Validator.escapeHtml(deck.deck_description || 'No description available');
-    const deckUrl = `index.html?deck=${encodeURIComponent(deck.deck_id)}`;
+    const deckUrl = `deck-study.html?deck=${encodeURIComponent(deck.deck_id)}`;
     
     // Determine deck status
     const isPublic = deck.deck_is_public;
@@ -76,6 +76,7 @@ function renderDeckCard(deck) {
                 </div>
             </div>
             <p class="deck-description">${safeDescription}</p>
+            <p class="deck-description practice-note">Practice mode – reviews do not affect your FSRS schedule.</p>
             <div class="deck-stats">
                 <span class="stat-item">
                     <span class="stat-label">Total:</span>

--- a/js/deckStudySessionManager.js
+++ b/js/deckStudySessionManager.js
@@ -1,0 +1,248 @@
+import { SESSION_CONFIG } from './config.js';
+import { Validator } from './validator.js';
+
+/**
+ * DeckStudySessionManager
+ * Lightweight session manager for deck-specific practice sessions.
+ * Sessions loaded through this manager do not mutate FSRS scheduling data.
+ */
+class DeckStudySessionManager {
+    constructor() {
+        this.sessionData = null;
+        this.dbService = null;
+        this.sessionStorageKey = 'deck_study_session';
+    }
+
+    detectStorageMethod() {
+        return 'memory';
+    }
+
+    hasSession() {
+        return Boolean(this.sessionData);
+    }
+
+    loadSession() {
+        // Deck study sessions are ephemeral and not restored across reloads
+        return false;
+    }
+
+    saveSession() {
+        // No persistence required for practice sessions
+    }
+
+    getSessionDeckId() {
+        return this.sessionData?.deckId || null;
+    }
+
+    getDeckMetadata() {
+        if (!this.sessionData) {
+            return null;
+        }
+
+        return {
+            id: this.sessionData.deckId,
+            name: this.sessionData.deckName,
+            totalCardsInSession: this.sessionData.totalCardsInSession,
+            totalAvailableCards: this.sessionData.metadata?.totalAvailableCards ?? this.sessionData.totalCardsInSession
+        };
+    }
+
+    generateSessionId(deckId) {
+        return `deck_study_${deckId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    shuffleCards(cards) {
+        const shuffled = [...cards];
+        for (let i = shuffled.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+        }
+        return shuffled;
+    }
+
+    transformCard(card, deck) {
+        const subjectName = card.subjects?.name || deck?.name || 'Deck Study';
+
+        return {
+            card_template_id: card.id,
+            cards: {
+                question: card.question,
+                answer: card.answer,
+                id: card.id,
+                subject_name: subjectName,
+                deck_name: deck?.name || 'Selected Deck',
+                tags: Array.isArray(card.tags) ? card.tags : []
+            },
+            stability: 1.0,
+            difficulty: 5.0,
+            state: 'practice',
+            total_reviews: 0,
+            due_at: null,
+            last_reviewed_at: null,
+            reps: 0,
+            lapses: 0,
+            correct_reviews: 0,
+            incorrect_reviews: 0,
+            _cardSource: 'deck-study'
+        };
+    }
+
+    async initializeSession(userId, dbService, options = {}) {
+        Validator.validateUserId(userId, 'deck study session');
+
+        const deckId = options.deckId;
+        if (!deckId || typeof deckId !== 'string' || deckId.trim() === '') {
+            throw new Error('Deck study requires a valid deck selection.');
+        }
+
+        this.dbService = dbService;
+
+        const preferredSize = SESSION_CONFIG?.CARDS_PER_SESSION || 10;
+        const requestedSize = Number.isInteger(options.sessionSize) ? options.sessionSize : preferredSize;
+
+        const { deck, cards, totalAvailable } = await dbService.getDeckStudyCards(deckId, requestedSize);
+
+        if (!cards || cards.length === 0) {
+            throw new Error('No cards available for the selected deck.');
+        }
+
+        const shuffledCards = this.shuffleCards(cards);
+        const sessionCards = shuffledCards.slice(0, Math.min(requestedSize, shuffledCards.length));
+
+        this.sessionData = {
+            sessionId: this.generateSessionId(deckId),
+            userId,
+            deckId,
+            deckName: deck?.name || 'Selected Deck',
+            cards: sessionCards.map(card => this.transformCard(card, deck)),
+            totalCardsInSession: sessionCards.length,
+            currentCardIndex: 0,
+            submittedCount: 0,
+            sessionType: 'deck-study',
+            status: 'created',
+            ratings: {},
+            completedCards: new Set(),
+            sessionStartTime: new Date().toISOString(),
+            metadata: {
+                sessionType: 'deck-study',
+                deckId,
+                deckName: deck?.name || 'Selected Deck',
+                totalAvailableCards: totalAvailable,
+                fsrsImpact: false
+            }
+        };
+
+        return true;
+    }
+
+    async shuffleAndFinalize(enableShuffle = true) {
+        if (!this.sessionData) {
+            return false;
+        }
+
+        if (enableShuffle) {
+            this.sessionData.cards = this.shuffleCards(this.sessionData.cards);
+        }
+
+        this.sessionData.currentCardIndex = 0;
+        this.sessionData.status = 'active';
+        return true;
+    }
+
+    getCurrentCard() {
+        if (!this.sessionData || !Array.isArray(this.sessionData.cards)) {
+            return null;
+        }
+
+        while (this.sessionData.currentCardIndex < this.sessionData.cards.length) {
+            const candidate = this.sessionData.cards[this.sessionData.currentCardIndex];
+            if (!candidate) {
+                break;
+            }
+
+            const cardId = String(candidate.card_template_id);
+            if (!this.sessionData.completedCards.has(cardId)) {
+                return candidate;
+            }
+
+            this.sessionData.currentCardIndex++;
+        }
+
+        return null;
+    }
+
+    async recordRating(rating, responseTime) {
+        if (!this.sessionData) {
+            throw new Error('No active deck study session.');
+        }
+
+        Validator.validateRating(rating, 'deck study');
+        Validator.validateResponseTime(responseTime, 'deck study');
+
+        const card = this.getCurrentCard();
+        if (!card) {
+            return false;
+        }
+
+        const cardId = String(card.card_template_id);
+        if (!this.sessionData.ratings[cardId]) {
+            this.sessionData.ratings[cardId] = [];
+        }
+
+        this.sessionData.ratings[cardId].push({
+            rating,
+            responseTime,
+            timestamp: new Date().toISOString()
+        });
+
+        this.sessionData.completedCards.add(cardId);
+        this.sessionData.submittedCount = Math.min(
+            this.sessionData.submittedCount + 1,
+            this.sessionData.totalCardsInSession
+        );
+        this.sessionData.currentCardIndex++;
+
+        return true;
+    }
+
+    isSessionComplete() {
+        if (!this.sessionData) {
+            return false;
+        }
+
+        return this.sessionData.submittedCount >= this.sessionData.totalCardsInSession;
+    }
+
+    getProgress() {
+        if (!this.sessionData) {
+            return { completed: 0, total: 0, percentage: 0, currentIndex: 0 };
+        }
+
+        const completed = this.sessionData.submittedCount;
+        const total = this.sessionData.totalCardsInSession;
+        const percentage = total > 0 ? (completed / total) * 100 : 0;
+        const currentIndex = Math.min(this.sessionData.currentCardIndex + 1, total);
+
+        return {
+            completed,
+            total,
+            percentage,
+            currentIndex
+        };
+    }
+
+    getSessionData() {
+        return this.sessionData;
+    }
+
+    async loadRatingsFromReviews() {
+        // Deck study sessions do not synchronize with review history
+    }
+
+    clearSession() {
+        this.sessionData = null;
+        this.dbService = null;
+    }
+}
+
+export default DeckStudySessionManager;


### PR DESCRIPTION
## Summary
- add a dedicated `deck-study.html` page that mirrors the study UI for deck-specific practice
- implement a client-side deck study session manager and database helpers to load deck cards without touching FSRS data
- update the main script, deck selection flow, and styles to surface deck practice messaging and routing

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce76acfa3883259576097244e79f86